### PR TITLE
Add command for searching manga on AniList

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,9 @@ venv.bak/
 # Rope project settings
 .ropeproject
 
+#VSCode project settings
+.vscode
+
 # mkdocs documentation
 /site
 

--- a/modules/anime/anilist.py
+++ b/modules/anime/anilist.py
@@ -39,6 +39,7 @@ class Anilist(graphene.ObjectType):
 	            meanScore
 	            popularity
 	            siteUrl
+				chapters
 	        }
 		}
 		'''

--- a/modules/anime/anilist.py
+++ b/modules/anime/anilist.py
@@ -5,6 +5,103 @@ import json
 from modules.core.client import Client
 
 class Anilist(graphene.ObjectType):
+	def aniSearchManga(show):
+		# query of info we want from AniList
+		query = '''
+		query ($id: Int, $search: String, $asHtml: Boolean) {
+	        Media (id: $id, search: $search, type: MANGA) {
+	            id
+				idMal
+	            title {
+	                romaji
+					english
+	            }
+	            status
+	            description(asHtml: $asHtml)
+	            startDate {
+	            	year
+	            	month
+	            	day
+	            }
+	            endDate {
+	            	year
+	            	month
+	            	day
+	            }
+	            season
+	            seasonYear
+	            coverImage {
+					extraLarge
+	            	large
+	            }
+	            bannerImage
+	            genres
+	            meanScore
+	            popularity
+	            siteUrl
+	        }
+		}
+		'''
+
+		variables = {
+		    'search': show,
+		    'asHtml': False,
+		}
+
+		source = 'https://graphql.anilist.co'
+
+		response = requests.post(source, json={'query': query, 'variables': variables})
+		result = response.json()
+
+		if response.status_code == 200:
+			return result
+		else:
+			print('Anime response code: ' + str(response.status_code) + '\n\n' + str(result))
+			return None
+
+	def charSearch(searchID):
+		query = '''
+			query ($id: Int, $search: String) {
+				Character (id: $id, search: $search) {
+					id
+					name {
+						full
+						alternative
+					}
+					image {
+						large
+					}
+					description
+					media {
+						nodes {
+							title {
+								romaji
+							}
+							coverImage {
+								medium
+							}
+							siteUrl
+						}
+					}
+					siteUrl
+				}
+			}
+		'''
+
+		variables = {
+			'search': searchID
+		}
+
+		url = 'https://graphql.anilist.co'
+
+		response = requests.post(url, json={'query': query, 'variables': variables})
+		result = response.json()
+
+		if response.status_code == 200:
+			return result
+		else:
+			print('Character response code: ' + str(response.status_code) + '\n\n' + str(result))
+			return None
 
 	def aniSearch(show):
 		# query of info we want from AniList

--- a/modules/cogs/anime.py
+++ b/modules/cogs/anime.py
@@ -187,7 +187,7 @@ class Anime(commands.Cog):
 			embed.add_field(name='Score', value=str(anilistResults['data']['Media']['meanScore']) + '%', inline=True)
 			embed.add_field(name='Popularity', value=str(anilistResults['data']['Media']['popularity']) + ' users', inline=True)
 			if 'RELEASING' not in status:
-
+				embed.add_field(name='Chapters', value=str(anilistResults['data']['Media']['chapters']), inline=False)
 				# find difference in year month and days of show's air time
 				try:
 					air = True

--- a/modules/cogs/anime.py
+++ b/modules/cogs/anime.py
@@ -147,6 +147,88 @@ class Anime(commands.Cog):
 		await ctx.send(embed=embed)
 
 	@al.command(pass_context=True)
+	async def manga(self, ctx):
+		comic = str(ctx.message.content)[(len(ctx.prefix) + len('al manga ')):]
+		# retrieve json file
+		anilistResults = Anilist.aniSearchManga(comic)
+		showID = anilistResults["data"]["Media"]["id"]
+
+		# parse out website styling
+		desc = shorten(str(anilistResults['data']['Media']['description']))
+
+		# make genre list look nice
+		gees = str(anilistResults['data']['Media']['genres'])
+		gees = gees.replace('\'', '')
+		gees = gees.replace('[', '')
+		gees = gees.replace(']', '')
+
+		# embed text to output
+		embed = discord.Embed(
+			title = str(anilistResults['data']['Media']['title']['romaji']),
+			description = desc,
+			color = discord.Color.blue(),
+			url = str(anilistResults['data']['Media']['siteUrl'])
+		)
+
+		embed.set_footer(text=gees)
+
+		# images, check if valid before displaying
+		if 'None' != str(anilistResults['data']['Media']['bannerImage']):
+			embed.set_image(url=str(anilistResults['data']['Media']['bannerImage']))
+
+		if 'None' != str(anilistResults['data']['Media']['coverImage']['large']):
+			embed.set_thumbnail(url=str(anilistResults['data']['Media']['coverImage']['large']))
+
+
+		# if show is airing, cancelled, finished, or not released
+		status = anilistResults['data']['Media']['status']
+
+		if 'NOT_YET_RELEASED' not in status:
+			embed.add_field(name='Score', value=str(anilistResults['data']['Media']['meanScore']) + '%', inline=True)
+			embed.add_field(name='Popularity', value=str(anilistResults['data']['Media']['popularity']) + ' users', inline=True)
+			if 'RELEASING' not in status:
+
+				# find difference in year month and days of show's air time
+				try:
+					air = True
+					years = abs(anilistResults['data']['Media']['endDate']['year'] - anilistResults['data']['Media']['startDate']['year'])
+					months = abs(anilistResults['data']['Media']['endDate']['month'] - anilistResults['data']['Media']['startDate']['month'])
+					days = abs(anilistResults['data']['Media']['endDate']['day'] - anilistResults['data']['Media']['startDate']['day'])
+				except TypeError:
+					print('Error calculating air time')
+					air = False
+
+				# get rid of anything with zero
+				if air:
+					tyme = str(days) + ' days'
+					if months != 0:
+						tyme += ', ' + str(months) + ' months'
+					if years != 0:
+						tyme += ', ' + str(years) + ' years'
+
+					embed.add_field(name='Released', value=tyme, inline=False)
+
+		users = 0
+		for user in ctx.guild.members:
+			try:
+				alID = User.userRead(str(user.id), "alID")
+				if users>=9:
+					break
+				if alID!=0:
+					scoreResults = Anilist.scoreSearch(alID, showID)["data"]["MediaList"]["score"]
+					statusResults = statusConversion(Anilist.scoreSearch(alID, showID)["data"]["MediaList"]["status"])
+					if scoreResults==0:
+						embed.add_field(name=user.name, value="No Score ("+statusResults+")", inline=True)
+						users+=1
+					else:
+						embed.add_field(name=user.name, value=str(scoreResults)+"/10 ("+statusResults+")", inline=True)
+						users+=1
+			except:
+				pass
+
+		await ctx.send(embed=embed)
+
+	@al.command(pass_context=True)
 	async def char(self, ctx):
 		c = str(ctx.message.content)[(len(ctx.prefix) + len('al char ')):]
 		anilistResults = Anilist.charSearch(c)


### PR DESCRIPTION
Add a command ">al manga {name}" which searches for manga on AniList. This is very similar to ">al search" with info not relevant to manga removed and some info relevant displayed.

Example for completed manga:
![image](https://user-images.githubusercontent.com/7919407/93134685-b3cc5580-f69e-11ea-85f4-ebc61deec5d6.png)

Example for releasing manga:
![image](https://user-images.githubusercontent.com/7919407/93134720-c181db00-f69e-11ea-89bf-80553b380f08.png)

