### PR TITLE
Add feedback in discord when bot gets a bad http response code.

### DIFF
--- a/modules/anime/anilist.py
+++ b/modules/anime/anilist.py
@@ -258,7 +258,7 @@ class Anilist(graphene.ObjectType):
 		response = requests.post(url, json={'query': query, 'variables': variables})
 		result = response.json()
 		
-		esponse.raise_for_status()
+		response.raise_for_status()
 		return result
 
 	def scoreSearch(user, media):
@@ -284,10 +284,8 @@ class Anilist(graphene.ObjectType):
 		response = requests.post(url, json={'query': query, 'variables': variables})
 		result = response.json()
 
-		if response.status_code == 200:
-			return result
-		else:
-			return None
+		response.raise_for_status()
+		return result
 
 	def activitySearch(user, time):
 		#implement query/statistics later

--- a/modules/anime/anilist.py
+++ b/modules/anime/anilist.py
@@ -57,11 +57,9 @@ class Anilist(graphene.ObjectType):
 		response = requests.post(source, json={'query': query, 'variables': variables})
 		result = response.json()
 
-		if response.status_code == 200:
-			return result
-		else:
-			print('Anime response code: ' + str(response.status_code) + '\n\n' + str(result))
-			return None
+		response.raise_for_status()
+		return result
+
 
 	def charSearch(searchID):
 		query = '''
@@ -101,11 +99,8 @@ class Anilist(graphene.ObjectType):
 		response = requests.post(url, json={'query': query, 'variables': variables})
 		result = response.json()
 
-		if response.status_code == 200:
-			return result
-		else:
-			print('Character response code: ' + str(response.status_code) + '\n\n' + str(result))
-			return None
+		response.raise_for_status()
+		return result
 
 	def aniSearch(show):
 		# query of info we want from AniList
@@ -164,11 +159,8 @@ class Anilist(graphene.ObjectType):
 		response = requests.post(source, json={'query': query, 'variables': variables})
 		result = response.json()
 
-		if response.status_code == 200:
-			return result
-		else:
-			print('Anime response code: ' + str(response.status_code) + '\n\n' + str(result))
-			return None
+		response.raise_for_status()
+		return result
 
 	def charSearch(searchID):
 		query = '''
@@ -208,11 +200,8 @@ class Anilist(graphene.ObjectType):
 		response = requests.post(url, json={'query': query, 'variables': variables})
 		result = response.json()
 
-		if response.status_code == 200:
-			return result
-		else:
-			print('Character response code: ' + str(response.status_code) + '\n\n' + str(result))
-			return None
+		response.raise_for_status()
+		return result
 
 	def userSearch(user):
 		#implement query/statistics later
@@ -268,12 +257,9 @@ class Anilist(graphene.ObjectType):
 
 		response = requests.post(url, json={'query': query, 'variables': variables})
 		result = response.json()
-
-		if response.status_code == 200:
-			return result
-		else:
-			print('User response code: ' + str(response.status_code) + '\n\n' + str(result))
-			return None
+		
+		esponse.raise_for_status()
+		return result
 
 	def scoreSearch(user, media):
 		#implement query/statistics later
@@ -352,11 +338,8 @@ class Anilist(graphene.ObjectType):
 
 		url = 'https://graphql.anilist.co'
 
-		response = requests.post(url, json={'query': query, 'variables': variables})
-		result = response.json()
-
-		if response.status_code == 200:
-			return result
+		response.raise_for_status()
+		return result
 
 	# for the user airing show searches
 	# input time as 00:00 of the day, 86400
@@ -402,5 +385,6 @@ class Anilist(graphene.ObjectType):
 		response = requests.post(url, json={'query': query, 'variables': variables})
 		result = response.json()
 
-		if response.status_code == 200:
-			return result
+		response.raise_for_status()
+		return result
+		

--- a/modules/cogs/anime.py
+++ b/modules/cogs/anime.py
@@ -4,6 +4,8 @@ from discord.ext.commands import has_permissions, CheckFailure
 import os, random, asyncio
 from os import path
 from dotenv import load_dotenv
+from aiohttp import ClientResponseError
+from requests import HTTPError
 
 from modules.core.client import Client
 from modules.core.database import Database
@@ -27,6 +29,10 @@ class Anime(commands.Cog):
 		try:
 			if isinstance(err, discord.ext.commands.MissingPermissions):
 				await ctx.send("You lack the needed permissions!")
+			elif isinstance(err, ClientResponseError):
+				await ctx.send("Query failed with status code %i!" % err.status)
+			elif isinstance(err, HTTPError):
+				await ctx.send(err.http_error_msg)
 			else:
 				await ctx.send('error!', file=discord.File(os.getcwd() + '/assets/lain_err_sm.png'))
 		except:

--- a/modules/core/session.py
+++ b/modules/core/session.py
@@ -5,7 +5,7 @@ class Session(commands.Cog):
 
 	def __init__(self, bot):
 		self.bot = bot
-		self.session = aiohttp.ClientSession()
+		self.session = aiohttp.ClientSession(raise_for_status=True)
 
 	async def close_session(self):
 		await self.session.close()


### PR DESCRIPTION
Changed wherever I found a http status code handled to throw an exception (using aiohttp and requests `raise_for_status()` which throws an exception for response codes >= 400) and handled it when a discord command is the cause by sending a message. No change was needed in loop.py because errors are already handled there (ignored).